### PR TITLE
disable husky when package published

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "main": "lib/index.js",
   "scripts": {
     "postinstall": "husky install",
+    "prepack": "pinst --disable",
+    "postpack": "pinst --enable",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "test": "jest",
     "testLint": "textlint-scripts test --exclude test/src/**/*",
@@ -55,6 +57,7 @@
     "@types/node": "^18.14.1",
     "husky": "^8.0.3",
     "jest": "^29.5.0",
+    "pinst": "^3.0.0",
     "semantic-release": "^20.1.1",
     "textlint-tester": "^13.3.0",
     "ts-jest": "^29.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5850,6 +5850,11 @@ pify@^4.0.1:
   resolved "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pinst@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pinst/-/pinst-3.0.0.tgz#80dec0a85f1f993c6084172020f3dbf512897eec"
+  integrity sha512-cengSmBxtCyaJqtRSvJorIIZXMXg+lJ3sIljGmtBGUVonMnMsVJbnzl6jGN1HkOWwxNuJynCJ2hXxxqCQrFDdw==
+
 pirates@^4.0.4, pirates@^4.0.5:
   version "4.0.5"
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz"


### PR DESCRIPTION
huskyコマンドはpublishするパッケージの場合、以下のようにpinstでhuskyを無効化する必要がある。

https://typicode.github.io/husky/#/?id=yarn-2