### PR TITLE
fix: include index.ts into npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "files": [
     "lib/",
+    "src/index.ts",
     "!lib/src",
     "!lib/regularRule",
     "!lib/test",


### PR DESCRIPTION
## 概要

- index.tsをどこかのタイミングでpublishするファイルから漏らしていた
- せっかくTypeScriptで書いているのに`import`や型補完が効かない状態となっていたため修正