### PR TITLE
docs: fixed typo (.textlinrc.yml -> .textlintrc.yml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ After installation, add the following to your `.textlintrc.json`:
 }
 ```
 
-If you're using yml (yaml) format like `.textlinrc.yml`, write it as follows:
+If you're using yml (yaml) format like `.textlintrc.yml`, write it as follows:
 
 ```yml
 rules:


### PR DESCRIPTION
This is a very useful textlint rule, thank you!